### PR TITLE
[WIP]投稿メッセージの自動更新

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,6 @@ $(function(){
   //最新の投稿メッセージのidを送信する
   var reloadMessages = function() {
     var last_message_id = $('.wrapper__chat-main__content__message:last').data("message-id");
-    console.log(last_message_id)
     $.ajax({
       url: "api/messages/",
       type: 'GET',

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,11 @@
 $(function(){
+
+  var last_message_id = $('.wrapper__chat-main__content__message:last').data("message-id");
+  console.log(last_message_id);
+
   function buildHTML(message) {
-     if (message.image) {
+    
+    if (message.image) {
       var html =
         ` <div class="wrapper__chat-main__content__message" > 
             <div class="wrapper__chat-main__content__message__info">

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,13 +1,38 @@
 $(function(){
 
-  var last_message_id = $('.wrapper__chat-main__content__message:last').data("message-id");
-  console.log(last_message_id);
+  //最新の投稿メッセージのidを送信する
+  var reloadMessages = function() {
+    var last_message_id = $('.wrapper__chat-main__content__message:last').data("message-id");
+    console.log(last_message_id)
+    $.ajax({
+      url: "api/messages/",
+      type: 'GET',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log(messages)
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.wrapper__chat-main__content').append(insertHTML);
+        $('.wrapper__chat-main__content').animate({ scrollTop: $('.wrapper__chat-main__content')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
 
+
+  //新規投稿されたメッセージ用のHTMLを生成する
   function buildHTML(message) {
     
     if (message.image) {
       var html =
-        ` <div class="wrapper__chat-main__content__message" > 
+        ` <div class="wrapper__chat-main__content__message" data-message-id=${message.id}> 
             <div class="wrapper__chat-main__content__message__info">
               <div class="wrapper__chat-main__content__message__info__contributor">
                 ${message.user_name}
@@ -26,7 +51,7 @@ $(function(){
       return html;
     } else{
       var html = 
-        ` <div class="wrapper__chat-main__content__message" > 
+        ` <div class="wrapper__chat-main__content__message" data-message-id=${message.id}> 
             <div class="wrapper__chat-main__content__message__info">
               <div class="wrapper__chat-main__content__message__info__contributor">
                 ${message.user_name}
@@ -43,6 +68,7 @@ $(function(){
     }
   }
 
+  //メッセージ投稿ボタンが押された時にメッセージ一覧を自動更新させる
   $('.wrapper__chat-main__message-form__content__form').on('submit', function(e){
     e.preventDefault()
     var formData = new FormData(this);
@@ -68,4 +94,9 @@ $(function(){
       $('.wrapper__chat-main__message-form__content__form__send').prop('disabled', false);
     });
   })
+
+  //定期的にreloadMessagesを呼び出す
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/index.json.jbuilder
+++ b/app/controllers/api/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,12 @@
+class Api::MessagesController < ApplicationController
+
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+  
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,12 +1,9 @@
 class Api::MessagesController < ApplicationController
-
+  
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
     # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
-  
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  json.user_name message.user.name
+  json.createtime message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.nickname
   json.id message.id
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -15,7 +15,7 @@
   //中央部 チャット履歴一覧
   .wrapper__chat-main__content
     - @messages.each do |message|
-      .wrapper__chat-main__content__message
+      .wrapper__chat-main__content__message{data: {message: {id: message.id}}}
         .wrapper__chat-main__content__message__info
           .wrapper__chat-main__content__message__info__contributor
             = message.user.nickname

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -20,7 +20,7 @@
           .wrapper__chat-main__content__message__info__contributor
             = message.user.nickname
           .wrapper__chat-main__content__message__info__timeline
-            = message.created_at
+            = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
         .wrapper__chat-main__content__message__text
           = message.content
         .wrapper__chat-main__content__message__image

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.user_name    @message.user.nickname 
-json.createtime   @message.created_at
+json.createtime   @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content      @message.content
 json.image        @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,13 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update, :delete]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 
-  namespace :api do
-    resources :messages, only: :index, defaults: { format: 'json' }
-  end
+
 
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end
- 
+
+  namespace :api do
+    resources :messages, only: :index, defaults: { format: 'json' }
+  end
 
 end
+


### PR DESCRIPTION
#what 
　新規で投稿したメッセージを他のブラウザでリロードすることなく、自動的にメッセージ一覧に反映するよう非同期通信による自動更新機能を実装する。

#why
　現状メッセージ投稿の操作をしたブラウザ以外では、リロードしなければメッセージ一覧が最新の状態に反映されない。chat-spaceはチャットツールとしての使用を想定しており、現状の機能では使用用途にそぐわないため。

実装後の挙動(GIFファイル)のURL
https://gyazo.com/062a9447ef77f6592c17df6fc4c9df9f